### PR TITLE
[1.x] GitHub actions and drop StyleCI

### DIFF
--- a/.github/workflows/fix-code-styling.yml
+++ b/.github/workflows/fix-code-styling.yml
@@ -1,0 +1,13 @@
+name: "Fix Code Styling"
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  lint:
+    uses: laravel/.github/.github/workflows/coding-standards.yml@main

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -1,0 +1,9 @@
+name: update changelog
+
+on:
+  release:
+    types: [released]
+
+jobs:
+  update:
+    uses: laravel/.github/.github/workflows/update-changelog.yml@main

--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,5 +1,0 @@
-php:
-  preset: laravel
-  version: 8
-  disabled:
-    - no_unused_imports


### PR DESCRIPTION
Adds two new github actions for code style and changelog updates. Also removes the StyleCI config