### PR TITLE
[1.x] Fix down migration from dropping the entire table

### DIFF
--- a/src/LaravelArchivableServiceProvider.php
+++ b/src/LaravelArchivableServiceProvider.php
@@ -29,7 +29,7 @@ class LaravelArchivableServiceProvider extends ServiceProvider
         });
 
         Blueprint::macro('dropArchivedAt', function ($column = 'archived_at') {
-            return $this->drop($column);
+            return $this->dropColumn($column);
         });
     }
 


### PR DESCRIPTION
When using ``drop()`` it should drop the whole table, you only want to drop a column